### PR TITLE
Remove varargs and lambda shorthands

### DIFF
--- a/src/Compile/EmitJS.hs
+++ b/src/Compile/EmitJS.hs
@@ -12,8 +12,6 @@ emitJS val = emitPrimitives ++ emitJS' val
 
 emitJS' :: Value -> String
 emitJS' (Call [Atom _ "fn", List _ params, body]) = "((" ++ intercalate "," (emitJS' <$> params) ++ ") => " ++ emitJS' body ++ ")"
-emitJS' (Call [Atom _ "fn", DottedList _ [] (Atom _ "%&"), body]) = "((...$$vararg) => " ++ emitJS' body ++ ")"
-emitJS' (Call [Atom _ "fn", DottedList _ params varargs, body]) = "((" ++ intercalate "," (emitJS' <$> params) ++ (if null params then "" else ",") ++ "..." ++ show varargs ++ ") => " ++ emitJS' body ++ ")"
 emitJS' (Call [Atom _ "unquote-splicing", val]) = "...(" ++ emitJS' val ++ ")"
 emitJS' (Call (Atom _ "let" : bindsAndExpr)) = "(function(){" ++ concat (emitBind <$> binds) ++ "return " ++ emitJS' expr ++ ";" ++ "})()"
   where

--- a/src/Compile/TypeSystem.hs
+++ b/src/Compile/TypeSystem.hs
@@ -36,8 +36,8 @@ typeSystem' stack steps z@(env, Call [Atom _ "if", pred, conseq, alt], _) = do
     deduceReturnType (TVar _) t = t
     deduceReturnType t (TVar _) = t
     deduceReturnType t1 t2 = flattenSum $ TSum [t1, t2]
-typeSystem' stack steps z@(_, Call (Func {vararg = vararg, params = params} : args), _) = do
-  if num params /= num args && isNothing vararg || num params > num args
+typeSystem' stack steps z@(_, Call (Func {params = params} : args), _) = do
+  if num params /= num args || num params > num args
     then throwError $ NumArgs (num params) args
     else do
       (newZ, newSteps) <- stepEval z

--- a/src/Data/Value.hs
+++ b/src/Data/Value.hs
@@ -7,8 +7,6 @@ module Data.Value
     float,
     func,
     fn,
-    makeNormalFunc,
-    makeVarArgs,
     makeLet,
     vzFromAST,
     vzToAST,
@@ -42,18 +40,8 @@ int = Integer
 float :: Double -> Value
 float = Float
 
-fn :: [Value] -> Maybe Value -> [Value] -> Value
-fn args Nothing body = Call (atom "fn" : list args : body)
-fn args (Just vararg) body = Call (atom "fn" : dottedList args vararg : body)
-
-makeFunc :: Maybe String -> Env -> [Value] -> Value -> Value
-makeFunc varargs env params body = Func (map show params) varargs body env
-
-makeNormalFunc :: Env -> [Value] -> Value -> Value
-makeNormalFunc = makeFunc Nothing
-
-makeVarArgs :: Value -> Env -> [Value] -> Value -> Value
-makeVarArgs = makeFunc . Just . show
+fn :: [Value] -> [Value] -> Value
+fn args body = Call (atom "fn" : list args : body)
 
 makeLet :: [(String, Value)] -> Value -> Value
 makeLet binds expr = Call $ (atom "let" : ((\(name, val) -> list [atom name, val]) <$> binds)) ++ [expr]

--- a/src/JSONInstances.hs
+++ b/src/JSONInstances.hs
@@ -19,7 +19,7 @@ instance ToJSON Value where
   toJSON (Map xs) = object ["type" .= ("map" :: String), "value" .= xs]
   toJSON (Call xs) = object ["type" .= ("call" :: String), "value" .= xs]
   toJSON (DottedList _ head tail) = object ["type" .= ("dotted-list" :: String), "head" .= head, "tail" .= tail]
-  toJSON (Func params vararg body closure) = object ["type" .= ("func" :: String), "params" .= params, "vararg" .= vararg, "body" .= body, "closure" .= closure]
+  toJSON (Func params body closure) = object ["type" .= ("func" :: String), "params" .= params, "body" .= body, "closure" .= closure]
   toJSON (PrimitiveFunc name _) = object ["type" .= ("primitive-func" :: String), "value" .= name]
   toJSON (IOFunc name _) = object ["type" .= ("io-func" :: String), "value" .= name]
   toJSON (Macro body closure) = object ["type" .= ("macro" :: String), "body" .= body, "closure" .= closure]

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -57,7 +57,7 @@ data Value
   | Call [Value]
   | PrimitiveFunc String ([Value] -> ThrowsError Value)
   | IOFunc String ([Value] -> IOThrowsError Value)
-  | Func {params :: [String], vararg :: Maybe String, body :: Value, closure :: Env}
+  | Func {params :: [String], body :: Value, closure :: Env}
   | Macro {body :: Value, closure :: Env}
   | Type Type
 
@@ -103,7 +103,7 @@ instance Eq Value where
   (Macro b1 c1) == (Macro b2 c2) = b1 == b2 && c1 == c2
   (Type t1) == (Type t2) = t1 == t2
   Unit == Unit = True
-  (Func p1 v1 b1 c1) == (Func p2 v2 b2 c2) = p1 == p2 && v1 == v2 && b1 == b2 && c1 == c2
+  (Func p1 b1 c1) == (Func p2 b2 c2) = p1 == p2 && b1 == b2 && c1 == c2
   _ == _ = False
 
 instance Show Value where
@@ -119,12 +119,8 @@ instance Show Value where
   show (Call contents) = "(" ++ unwordsList contents ++ ")"
   show (DottedList _ head tail) = "[" ++ unwordsList head ++ " . " ++ show tail ++ "]"
   show (PrimitiveFunc name _) = "<primitive " ++ name ++ ">"
-  show Func {params = args, vararg = varargs, body = body} =
+  show Func {params = args, body = body} =
     "{fn [" ++ unwords (map show args)
-      ++ ( case varargs of
-             Nothing -> ""
-             Just arg -> " . " ++ arg
-         )
       ++ "] "
       ++ show body
       ++ "}"

--- a/test/JsNodeTests/test1/input.clsk
+++ b/test/JsNodeTests/test1/input.clsk
@@ -3,5 +3,5 @@
   [m (fn [a b] (- a b))]
   [n (m 11 1)]
   [!$%&|*+-/:<=>?^_test (+ 3 5)]
-  [io.dump #(io.write (string.from %%))]
+  [io.dump (fn [%%] (io.write (string.from %%)))]
   (io.dump (+ !$%&|*+-/:<=>?^_test (+ n k))))

--- a/test/JsNodeTests/test2/input.clsk
+++ b/test/JsNodeTests/test2/input.clsk
@@ -1,10 +1,10 @@
 (let
-  [not #(if %% false true)]
-  [null? #(if (eq? %% []) true false)]
+  [not (fn [pred] (if pred false true))]
+  [null? (fn [pred ](if (eq? pred []) true false))]
   [first car]
   [next cdr]
-  [second #(first (next %%))]
-  [list (fn [. objs] objs)]
+  [second (fn [lst] (first (next lst)))]
+  [list (fn [objs] objs)]
   [id (fn [arg] arg)]
   [flip (fn [func] (fn [arg1 arg2] (func arg2 arg1)))]
   [compose (fn [f g] (fn [arg] (f (g arg))))]
@@ -22,20 +22,20 @@
     (if (pred init)
         (cons init [])
         (cons init (unfold func (func init) pred))))]
-  [max (fn [first . rest] (foldl (fn [old new] (if (> old new) old new)) first rest))]
-  [min (fn [first . rest] (foldl (fn [old new] (if (< old new) old new)) first rest))]
+  [max (fn [first rest] (foldl (fn [old new] (if (> old new) old new)) first rest))]
+  [min (fn [first rest] (foldl (fn [old new] (if (< old new) old new)) first rest))]
   [length (fn [lst] (foldl (fn [x y] (+ x 1)) 0 lst))]
   [reverse (fn [lst] (foldl (flip cons) [] lst))]
   [map (fn [func lst] (foldr (fn [x y] (cons (func x) y)) [] lst))]
   [filter (fn [pred lst] (foldr (fn [x y] (if (pred x) (cons x y) y)) [] lst))]
-  [complement (fn [func] #(not (func %%)))]
+  [complement (fn [func] (fn [v] (not (func v))))]
   [remove (fn [pred lst] (filter (complement pred) lst))]
   [append (fn [l1 l2] (foldr cons l2 l1))]
-  [io.dump #(io.write (string.from %%))]
+  [io.dump (fn [v] (io.write (string.from v)))]
   (do
-    (io.dump (foldr #(id %1) 1 [3 2 4]))
-    (io.dump (filter #(< 5 %%) [1 3 5 7]))
-    (io.dump (remove #(< 5 %%) [1 3 5 7]))
+    (io.dump (foldr id 1 [3 2 4]))
+    (io.dump (filter (fn [n] (< 5 n)) [1 3 5 7]))
+    (io.dump (remove (fn [n] (< 5 n)) [1 3 5 7]))
     (io.dump (reverse [1 3 5 7]))
-    (io.dump (unfold (compose #(+ %% 1) #(- %% 2)) 10 #(> 5 %%)))
+    (io.dump (unfold (compose (fn [n] (+ n 1)) (fn [n] (- n 2))) 10 (fn [n] (> 5 n))))
     ))

--- a/test/JsNodeTests/test3/input.clsk
+++ b/test/JsNodeTests/test3/input.clsk
@@ -1,1 +1,1 @@
-(io.write (string.from (#(+ %% 4) 5)))
+(io.write (string.from ((fn [n] (+ n 4)) 5)))


### PR DESCRIPTION
Maybe someday macros will be able to implement such features.